### PR TITLE
Quantization QMatMul

### DIFF
--- a/src/acetone_nnet/cli/generate.py
+++ b/src/acetone_nnet/cli/generate.py
@@ -34,10 +34,11 @@ def cli_acetone(
     target: str = "generic",
     target_page_size: int = 4096,
     test_dataset_file: str | None = None,
+    verbose:bool = False,
     *,
     normalize: bool = False,
 ) -> None:
-    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+    logging.basicConfig(level=logging.INFO if verbose else logging.WARNING, format='%(asctime)s - %(levelname)s - %(message)s')
     """Generate code with ACETONE."""
     logging.info("C CODE GENERATOR FOR NEURAL NETWORKS")
     logging.info(f'Target {target} selected')
@@ -51,6 +52,7 @@ def cli_acetone(
         target=target,
         target_page_size=target_page_size,
         versions={"Conv2D": conv_algorithm},
+        verbose=verbose
     )
     net.generate_c_files(output_dir)
     net.compute_inference(output_dir)
@@ -116,6 +118,13 @@ def acetone_generate() -> None:
         help="page size of the target in bytes",
     )
 
+    parser.add_argument(
+        "--verbose",
+        default=False,
+        type=bool,
+        help="verbose logging at INFO level else WARNING level",
+    )
+
     args = parser.parse_args()
 
     cli_acetone(
@@ -128,6 +137,7 @@ def acetone_generate() -> None:
         test_dataset_file=args.dataset,
         normalize=args.normalize,
         target_page_size=args.target_page_size,
+        verbose=args.verbose
     )
 
 

--- a/src/acetone_nnet/cli/generate.py
+++ b/src/acetone_nnet/cli/generate.py
@@ -22,7 +22,6 @@
 import argparse
 import logging
 import pathlib
-
 from acetone_nnet import CodeGenerator
 
 
@@ -38,11 +37,11 @@ def cli_acetone(
     *,
     normalize: bool = False,
 ) -> None:
+    logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
     """Generate code with ACETONE."""
     logging.info("C CODE GENERATOR FOR NEURAL NETWORKS")
-    print(target, " selected")
+    logging.info(f'Target {target} selected')
     pathlib.Path(output_dir).mkdir(parents=True, exist_ok=True)
-
     net = CodeGenerator(
         file=model_file,
         test_dataset=test_dataset_file,

--- a/src/acetone_nnet/cli/generate.py
+++ b/src/acetone_nnet/cli/generate.py
@@ -35,6 +35,7 @@ def cli_acetone(
     target_page_size: int = 4096,
     test_dataset_file: str | None = None,
     verbose:bool = False,
+    to_hex:bool = True,
     *,
     normalize: bool = False,
 ) -> None:
@@ -52,7 +53,8 @@ def cli_acetone(
         target=target,
         target_page_size=target_page_size,
         versions={"Conv2D": conv_algorithm},
-        verbose=verbose
+        verbose=verbose,
+        to_hex=to_hex
     )
     net.generate_c_files(output_dir)
     net.compute_inference(output_dir)

--- a/src/acetone_nnet/debug/debug_keras.py
+++ b/src/acetone_nnet/debug/debug_keras.py
@@ -23,8 +23,12 @@ from pathlib import Path
 
 import keras
 import numpy as np
-from keras.engine.functional import Functional
-from keras.engine.sequential import Sequential
+try:
+    from keras.engine.functional import Functional
+    from keras.engine.sequential import Sequential
+except ImportError:
+    from keras import Model as Functional
+    from keras import Sequential
 
 
 def extract_node_outputs(model: Sequential | Functional) -> list[str]:

--- a/src/acetone_nnet/generator/cuda.py
+++ b/src/acetone_nnet/generator/cuda.py
@@ -5,8 +5,12 @@ from typing import Any, Self
 import numpy as np
 import onnx
 import pystache
-from keras.engine.functional import Functional
-from keras.engine.sequential import Sequential
+try:
+    from keras.engine.functional import Functional
+    from keras.engine.sequential import Sequential
+except ImportError:
+    from keras import Model as Functional
+    from keras import Sequential
 
 from acetone_nnet import templates
 from acetone_nnet.generator.layers import (

--- a/src/acetone_nnet/generator/neural_network.py
+++ b/src/acetone_nnet/generator/neural_network.py
@@ -450,6 +450,8 @@ class CodeGenerator(ABC):
         return nn_output
 
     def data2c(self, d):
+        if self.data_type_py==np.int16:
+            return str(int(d*32767))
         if self.to_hex:
             return float.hex(float(d)).replace("0000000p", "p")
         else:
@@ -545,7 +547,7 @@ class CodeGenerator(ABC):
                         "data_type": self.data_type,
                         "read_input": self.read_ext_input,
                         "verbose":self.verbose,
-                        "to_hex":self.to_hex,
+                        "format":"%a" if self.to_hex else "%9g",
                     },
                 ),
             )

--- a/src/acetone_nnet/generator/neural_network.py
+++ b/src/acetone_nnet/generator/neural_network.py
@@ -892,12 +892,12 @@ class CodeGenerator(ABC):
                     qformat = self.target_cfg['quantization']['layers'][l.name+'_'+str(l.idx)]['params']
                     logging.info(f'Quantize qformat for {l.name}_{l.idx} : {qformat}')
                     (n,m) = qform.parse_q_format(qformat)
-                    if hasattr(l, "weights"):
-                        l.weights = np.rint(l.weights*(2**m-1)).astype(self.data_type_py)
-                    if hasattr(l, "biases"):
-                        l.biases = np.rint(l.weights*(2**m-1)).astype(self.data_type_py)
                 except KeyError as e:
                     pass
+                if hasattr(l, "weights"):
+                    l.weights = np.rint(l.weights*(2**m-1)).astype(self.data_type_py)
+                if hasattr(l, "biases"):
+                    l.biases = np.rint(l.weights*(2**m-1)).astype(self.data_type_py)
 
     def generate_globalvars_file(
         self: Self,

--- a/src/acetone_nnet/generator/neural_network.py
+++ b/src/acetone_nnet/generator/neural_network.py
@@ -451,17 +451,14 @@ class CodeGenerator(ABC):
 
     def data2c(self, d):
         if self.data_type_py==np.int16:
-            return str(int(d*32767))
+            return str(int(d*1000))
         if self.to_hex:
             return float.hex(float(d)).replace("0000000p", "p")
         else:
             return str(float(d))
 
     def c2data(self, c):
-        if self.to_hex:
-            return float.fromhex(c)
-        else:
-            return float(f)
+        return float.fromhex(c) if self.to_hex else float(c)
 
     def flatten_array_order_c(self:Self, array: np.ndarray) -> str:
         """Generate C flat array initializer in C order."""

--- a/src/acetone_nnet/generator/neural_network.py
+++ b/src/acetone_nnet/generator/neural_network.py
@@ -80,7 +80,7 @@ class CodeGenerator(ABC):
         versions: dict[int, str] | dict[str, str] | None = None,
         normalize: bool | str = False,
         debug_mode: str | None = None,
-        verbose: bool = True,
+        verbose: bool = False,
         to_hex: bool = True,
         **kwargs,
     ) -> None:
@@ -592,30 +592,22 @@ class CodeGenerator(ABC):
                 raise FileExistsError(c_files_directory / file)
 
         self.generate_function_source_file(c_files_directory)
-        if self.verbose:
-            logging.info("Generated function source file.")
+        logging.info("Generated function source file.")
         self.generate_function_header_file(c_files_directory)
-        if self.verbose:
-            logging.info("Generated function header file.")
+        logging.info("Generated function header file.")
         self.generate_globalvars_file(c_files_directory)
-        if self.verbose:
-            logging.info("Generated globalvars .c file.")
+        logging.info("Generated globalvars .c file.")
         self.generate_main_file(c_files_directory)
-        if self.verbose:
-            logging.info("Generated main file.")
+        logging.info("Generated main file.")
         self.generate_makefile(c_files_directory)
-        if self.verbose:
-            logging.info("Generated Makefile.")
+        logging.info("Generated Makefile.")
         self.generate_test_dataset_files(c_files_directory)
-        if self.verbose:
-            logging.info("Generated test_dataset files.")
+        logging.info("Generated test_dataset files.")
         if self.target != "generic":
             self.generate_target_file(c_files_directory)
-            if self.verbose:
-                logging.info("Generated target file.")
+            logging.info("Generated target file.")
             self.generate_target_header_file(c_files_directory)
-            if self.verbose:
-                logging.info("Generated target header file.")
+            logging.info("Generated target header file.")
 
     def generate_target_file(self: Self, output_dir: Path) -> None:
         logging.info("Generation of target file")

--- a/src/acetone_nnet/generator/neural_network.py
+++ b/src/acetone_nnet/generator/neural_network.py
@@ -547,7 +547,7 @@ class CodeGenerator(ABC):
                         "data_type": self.data_type,
                         "read_input": self.read_ext_input,
                         "verbose":self.verbose,
-                        "format":"%a" if self.to_hex else "%9g",
+                        "format":"%d" if np.issubdtype(self.data_type_py,np.integer) else "%a" if self.to_hex else "%9g",
                     },
                 ),
             )

--- a/src/acetone_nnet/importers/parser.py
+++ b/src/acetone_nnet/importers/parser.py
@@ -23,8 +23,12 @@ from pathlib import Path
 from typing import Any
 
 import onnx
-from keras.engine.functional import Functional
-from keras.engine.sequential import Sequential
+try:
+    from keras.engine.functional import Functional
+    from keras.engine.sequential import Sequential
+except ImportError:
+    from keras import Model as Functional
+    from keras import Sequential
 from acetone_nnet.generator import Layer
 
 

--- a/src/acetone_nnet/quantize/qform.py
+++ b/src/acetone_nnet/quantize/qform.py
@@ -1,0 +1,45 @@
+import re
+
+def parse_q_format(q_string: str) -> tuple[int, int] | None:
+    """
+    Parses a string in the Qx.y format using a regular expression.
+
+    The Q format is a fixed-point number representation. "x" represents the
+    number of integer bits, and "y" represents the number of fractional bits.
+
+    Args:
+        q_string: The string to parse, expected in "Qx.y" format.
+
+    Returns:
+        A tuple containing the two integers (x, y) if the format is valid.
+        Returns None if the input string does not match the expected format.
+    """
+    # Define the regular expression pattern.
+    # - ^ asserts position at start of the string.
+    # - Q matches the literal character 'Q'.
+    # - (\d+) captures one or more digits. This is the first capturing group (for x).
+    # - \. matches the literal character '.'. The backslash escapes the dot,
+    #   which is a special character in regex (matches any character).
+    # - (\d+) captures one or more digits. This is the second capturing group (for y).
+    # - $ asserts position at the end of the string.
+    pattern = r"^Q(\d+)\.(\d+)$"
+
+    # Use re.match() to find a match at the beginning of the string.
+    match = re.match(pattern, q_string)
+
+    # Check if a match was found.
+    if match:
+        # The match object's groups() method returns a tuple of all captured groups.
+        # group(1) corresponds to the first (\d+), which is 'x'.
+        # group(2) corresponds to the second (\d+), which is 'y'.
+        x_str, y_str = match.groups()
+
+        # Convert the extracted string parts to integers.
+        x = int(x_str)
+        y = int(y_str)
+
+        return (x, y)
+    else:
+        # If the pattern does not match, return None.
+        return None
+

--- a/src/acetone_nnet/templates/AVX512VNNI/template_target_file.c.tpl
+++ b/src/acetone_nnet/templates/AVX512VNNI/template_target_file.c.tpl
@@ -1,0 +1,1 @@
+// AVX512VNNI target

--- a/src/acetone_nnet/templates/AVX512VNNI/template_target_file.h.tpl
+++ b/src/acetone_nnet/templates/AVX512VNNI/template_target_file.h.tpl
@@ -1,0 +1,3 @@
+#ifdef __AVX512VNNI__
+#include <immintrin.h> // Main header for Intel intrinsics
+#endif

--- a/src/acetone_nnet/templates/layers/template_MatMul.c.tpl
+++ b/src/acetone_nnet/templates/layers/template_MatMul.c.tpl
@@ -21,5 +21,5 @@
     }
     for (k = 0; k < {{size}}; ++k)
     {
-        output_{{road}}[k] = tensor_temp[k];
+        output_{{road}}[k] = {{qcast}}tensor_temp[k]{{qshift}};
     }

--- a/src/acetone_nnet/templates/layers/template_QMatMul.vnni16.tpl
+++ b/src/acetone_nnet/templates/layers/template_QMatMul.vnni16.tpl
@@ -1,0 +1,25 @@
+    // {{name}}_{{idx}}{{comment}}
+    for (f = 0; f < {{output_channels}}; ++f)
+    {
+        for (i = 0; i < {{output_height}}; ++i)
+        {
+            for (j = 0; j < {{output_width}}; ++j)
+            {
+                tensor_temp[j + {{output_width}}*(i + {{output_height}}*f)] = 0;
+                for (k = 0; k < {{shared_dimension}}; ++k)
+                {
+                    tensor_temp[j + {{output_width}}*(i + {{output_height}}*f)] += {{output_str_left}}[k + {{shared_dimension}}*(i + {{output_height}}*f)]*{{output_str_right}}[j + {{output_width}}*(k + {{shared_dimension}}*f)];
+                }
+                {{#non_linear}}
+                tensor_temp[j + {{output_width}}*(i + {{output_height}}*f)] = {{{activation_function}}};
+                {{/non_linear}}
+                {{#fused_layer}}
+                tensor_temp[j + {{output_width}}*(i + {{output_height}}*f)] = {{{fused_layer}}};
+                {{/fused_layer}}
+            }
+        }
+    }
+    for (k = 0; k < {{size}}; ++k)
+    {
+        output_{{road}}[k] = tensor_temp[k];
+    }

--- a/src/acetone_nnet/templates/template_global_var_file.c.tpl
+++ b/src/acetone_nnet/templates/template_global_var_file.c.tpl
@@ -13,7 +13,7 @@
 {{/cst}}
 
 {{#temp_size}}
-{{data_type}} tensor_temp[{{temp_size}}] __attribute__((aligned({{page_size}})));
+{{temp_data_type}} tensor_temp[{{temp_size}}] __attribute__((aligned({{page_size}})));
 
 {{/temp_size}}
 {{#zero}}

--- a/src/acetone_nnet/templates/template_header_file.c.tpl
+++ b/src/acetone_nnet/templates/template_header_file.c.tpl
@@ -13,7 +13,7 @@ extern {{data_type}} cst_{{name}}[{{size}}];
 {{/cst}}
 
 {{#temp_size}}
-extern {{data_type}} tensor_temp[{{temp_size}}];
+extern {{temp_data_type}} tensor_temp[{{temp_size}}];
 
 {{/temp_size}}
 {{#layers}}

--- a/src/acetone_nnet/templates/template_main_file.c.tpl
+++ b/src/acetone_nnet/templates/template_main_file.c.tpl
@@ -55,10 +55,9 @@ int main(int argc, char** argv)
     {
         for (j = 0; j < nn_output_size; ++j)
         {
-            {{#to_hex}}fprintf(fp,"%a ", predictions[i][j]);{{/to_hex}}
-            {{^to_hex}}fprintf(fp,"%.9g ", predictions[i][j]);{{/to_hex}}
+            fprintf(fp,"{{format}} ", predictions[i][j]);
             {{#verbose}}
-            printf("%.9g ", predictions[i][j]);
+            printf("{{format}} ", predictions[i][j]);
             {{/verbose}}
             if (j == nn_output_size - 1)
             {

--- a/src/acetone_nnet/templates/template_source_file.c.tpl
+++ b/src/acetone_nnet/templates/template_source_file.c.tpl
@@ -40,7 +40,7 @@ int inference({{data_type}} prediction[{{output_size}}], {{data_type}} nn_input[
     {{/hw}}
 
 {{#is_dense}}
-    {{data_type}} dotproduct;
+    {{temp_data_type}} dotproduct;
 {{/is_dense}}
 {{#is_sum}}
     {{data_type}} sum;

--- a/tests/test_quantize.py
+++ b/tests/test_quantize.py
@@ -1,0 +1,46 @@
+import unittest
+#import acetone_nnet
+from acetone_nnet.quantize.qform import parse_q_format
+# --- Unit Tests ---
+
+class TestParseQFormat(unittest.TestCase):
+    """
+    Test suite for the parse_q_format function.
+    """
+
+    def test_valid_format(self):
+        """Tests parsing of valid Q format strings."""
+        self.assertEqual(parse_q_format("Q15.16"), (15, 16))
+        self.assertEqual(parse_q_format("Q3.28"), (3, 28))
+        self.assertEqual(parse_q_format("Q0.8"), (0, 8))
+        self.assertEqual(parse_q_format("Q1.0"), (1, 0))
+
+    def test_invalid_prefix(self):
+        """Tests strings with an incorrect prefix."""
+        self.assertIsNone(parse_q_format("A15.16"))
+        self.assertIsNone(parse_q_format("q15.16")) # Case-sensitive
+
+    def test_missing_parts(self):
+        """Tests strings that are missing parts of the format."""
+        self.assertIsNone(parse_q_format("Q15"))
+        self.assertIsNone(parse_q_format("Q.16"))
+        self.assertIsNone(parse_q_format("Q15."))
+
+    def test_non_digit_characters(self):
+        """Tests strings containing non-digit characters for x or y."""
+        self.assertIsNone(parse_q_format("Q15.a16"))
+        self.assertIsNone(parse_q_format("Qx.16"))
+        self.assertIsNone(parse_q_format("Q15.16b"))
+
+    def test_empty_and_malformed_strings(self):
+        """Tests various other malformed strings."""
+        self.assertIsNone(parse_q_format(""))
+        self.assertIsNone(parse_q_format("Q."))
+        self.assertIsNone(parse_q_format("Not a Q string"))
+
+
+# This allows the test suite to be run from the command line.
+if __name__ == '__main__':
+    # Using argv and exit=False makes it compatible with some environments
+    # that might not handle sys.exit() well.
+    unittest.main(argv=['first-arg-is-ignored'], exit=False)

--- a/tests/tests_inference/acetoneTestCase.py
+++ b/tests/tests_inference/acetoneTestCase.py
@@ -72,27 +72,18 @@ def create_initializer_tensor(
     )
 
 
-def read_output_c(path_to_output: str) -> np.ndarray:
+def read_output_c(path_to_output: str, target: str, trimline: int=-2) -> np.ndarray:
     """Read the output file of the C code."""
     with open(path_to_output) as f:
         line = f.readline()
-        line = line[:-2].split(" ")
-        line = list(map(float.fromhex, line))
-        line = np.array(line)
-    f.close()
-    return line
+        words = line[:trimline].split(" ")
+        if target=='generic':
+            return np.array(list(map(float.fromhex, words)))
+        else:
+            return np.array(list(map(int, words)))
 
-
-def read_output_python(path_to_output: str) -> np.ndarray:
-    """Read the output file of the python code."""
-    with open(path_to_output) as f:
-        line = f.readline()
-        line = line[:-3].split(" ")
-        line = list(map(float.fromhex, line))
-        line = np.array(line)
-    f.close()
-    return line
-
+def read_output_python(path_to_output: str, target: str) -> np.ndarray:
+    return read_output_c(path_to_output, target, trimline=-3)
 
 def create_dataset(tmpdir: str, shape: tuple):
     """Create a random dataset."""
@@ -129,7 +120,7 @@ def run_acetone_for_test(
     )
 
     if run_reference:
-        output_python = read_output_python(tmpdir_name + "/output_python.txt").flatten()
+        output_python = read_output_python(tmpdir_name + "/output_python.txt", target).flatten()
     else:
         output_python = None
 
@@ -146,7 +137,7 @@ def run_acetone_for_test(
             print("\nC code inference failed")
             return np.array([]), output_python
 
-        output_c = read_output_c(tmpdir_name + "/output_c.txt").flatten()
+        output_c = read_output_c(tmpdir_name + "/output_c.txt",target).flatten()
     else:
         output_c = None
 

--- a/tests/tests_inference/acetoneTestCase.py
+++ b/tests/tests_inference/acetoneTestCase.py
@@ -35,7 +35,6 @@ class AcetoneTestCase(unittest.TestCase):
         """Create a temp_dir."""
         self.tmpdir = tempfile.TemporaryDirectory()
         self.tmpdir_name = self.tmpdir.name
-        self.tmpdir_name = 'temp'
 
     def tearDown(self) -> None:
         """Destroy a temp_dir."""

--- a/tests/tests_inference/acetoneTestCase.py
+++ b/tests/tests_inference/acetoneTestCase.py
@@ -31,11 +31,11 @@ from acetone_nnet.cli.generate import cli_acetone
 
 class AcetoneTestCase(unittest.TestCase):
     """TestCase class for inference tests."""
-
     def setUp(self) -> None:
         """Create a temp_dir."""
         self.tmpdir = tempfile.TemporaryDirectory()
         self.tmpdir_name = self.tmpdir.name
+        self.tmpdir_name = 'temp'
 
     def tearDown(self) -> None:
         """Destroy a temp_dir."""
@@ -114,6 +114,7 @@ def run_acetone_for_test(
     normalize=False,
     run_generated=True,
     run_reference=True,
+    target='generic',
 ):
     cli_acetone(
         model_file=model,
@@ -123,6 +124,8 @@ def run_acetone_for_test(
         output_dir=tmpdir_name,
         test_dataset_file=datatest_path,
         normalize=normalize,
+        target=target,
+        verbose=True
     )
 
     if run_reference:

--- a/tests/tests_inference/tests_layer/test_c_python/test_QMatMul.py
+++ b/tests/tests_inference/tests_layer/test_c_python/test_QMatMul.py
@@ -1,0 +1,169 @@
+"""*******************************************************************************
+* ACETONE: Predictable programming framework for ML applications in safety-critical systems
+* Copyright (c) 2022. ONERA
+* This file is part of ACETONE
+*
+* ACETONE is free software ;
+* you can redistribute it and/or modify it under the terms of the GNU Lesser General Public
+* License as published by the Free Software Foundation ;
+* either version 3 of  the License, or (at your option) any later version.
+*
+* ACETONE is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY ;
+* without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+* See the GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License along with this program ;
+* if not, write to the Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307  USA
+******************************************************************************
+"""
+
+from tests.tests_inference import acetoneTestCase
+acetoneTestCase_path = '/'.join(__file__.split('/')[:-3])
+import sys
+sys.path.append(acetoneTestCase_path)
+import acetoneTestCase
+
+import tensorflow as tf
+import onnx
+import numpy as np
+
+from tests.tests_inference import acetoneTestCase
+
+tf.keras.backend.set_floatx("float32")
+
+
+class TestMatMul(acetoneTestCase.AcetoneTestCase):
+    """Test for Dense Layer"""
+
+    def test_MatMul0(self):
+        # IO tensors (ValueInfoProto).
+        model_input_name = "X"
+        X = onnx.helper.make_tensor_value_info(model_input_name,
+                                               onnx.TensorProto.FLOAT,
+                                               [None, 1, 1, 5])
+        model_output_name = "Y"
+        Y = onnx.helper.make_tensor_value_info(model_output_name,
+                                               onnx.TensorProto.FLOAT,
+                                               [None, 1, 1, 50])
+
+        matmul_W = np.random.rand(5, 50).astype(np.float32)
+        matmul_W_name = "W0"
+        matmul_W_initializer_tensor = acetoneTestCase.create_initializer_tensor(matmul_W_name,
+                                                                                matmul_W,
+                                                                                onnx.TensorProto.FLOAT)
+
+        matmul_node_name = "Matmul"
+        matmul_node = onnx.helper.make_node(
+            name=matmul_node_name,
+            op_type="MatMul",
+            inputs=[model_input_name, matmul_W_name],
+            outputs=[model_output_name],
+        )
+
+        # Create the graph (GraphProto)
+        graph_def = onnx.helper.make_graph(
+            nodes=[matmul_node],
+            name="ONNX_matmul",
+            inputs=[X],  # Graph input
+            outputs=[Y],  # Graph output
+            initializer=[
+                matmul_W_initializer_tensor,
+            ],
+        )
+
+        # Create the model (ModelProto)
+        model_def = onnx.helper.make_model(graph_def, producer_name="onnx-example")
+        model_def.opset_import[0].version = 13
+        onnx.checker.check_model(model_def)
+        onnx.save(model_def, self.tmpdir_name + "/model.onnx")
+
+        acetone_result = acetoneTestCase.run_acetone_for_test(self.tmpdir_name, self.tmpdir_name + "/model.onnx",target='AVX512VNNI')
+
+        self.assertListAlmostEqual(list(acetone_result[0]), list(acetone_result[1]))
+'''
+    def test_MatMul1(self):
+        # IO tensors (ValueInfoProto).
+        model_input_name = "X"
+        X = onnx.helper.make_tensor_value_info(model_input_name,
+                                               onnx.TensorProto.FLOAT,
+                                               [None, 1, 5, 1])
+        model_output_name = "Y"
+        Y = onnx.helper.make_tensor_value_info(model_output_name,
+                                               onnx.TensorProto.FLOAT,
+                                               [None, 1, 50, 1])
+
+        matmul_W = np.random.rand(50, 5).astype(np.float32)
+        matmul_W_name = "W0"
+        matmul_W_initializer_tensor = acetoneTestCase.create_initializer_tensor(matmul_W_name,
+                                                                                matmul_W,
+                                                                                onnx.TensorProto.FLOAT)
+
+        matmul_node_name = "Matmul"
+        matmul_node = onnx.helper.make_node(
+            name=matmul_node_name,
+            op_type="MatMul",
+            inputs=[matmul_W_name, model_input_name],
+            outputs=[model_output_name],
+        )
+
+        # Create the graph (GraphProto)
+        graph_def = onnx.helper.make_graph(
+            nodes=[matmul_node],
+            name="ONNX_matmul",
+            inputs=[X],  # Graph input
+            outputs=[Y],  # Graph output
+            initializer=[
+                matmul_W_initializer_tensor,
+            ],
+        )
+
+        # Create the model (ModelProto)
+        model_def = onnx.helper.make_model(graph_def, producer_name="onnx-example")
+        model_def.opset_import[0].version = 13
+        onnx.checker.check_model(model_def)
+        onnx.save(model_def, self.tmpdir_name + "/model.onnx")
+
+        acetone_result = acetoneTestCase.run_acetone_for_test(self.tmpdir_name, self.tmpdir_name + "/model.onnx",target='AVX512VNNI')
+
+        self.assertListAlmostEqual(acetone_result[0], acetone_result[1])
+
+    def test_MatMul2(self):
+        # IO tensors (ValueInfoProto).
+        model_input_name = "X"
+        X = onnx.helper.make_tensor_value_info(model_input_name,
+                                               onnx.TensorProto.FLOAT,
+                                               [None, 3, 10, 10])
+        model_output_name = "Y"
+        Y = onnx.helper.make_tensor_value_info(model_output_name,
+                                               onnx.TensorProto.FLOAT,
+                                               [None, 3, 10, 10])
+
+        matmul_node_name = "Matmul"
+        matmul_node = onnx.helper.make_node(
+            name=matmul_node_name,
+            op_type="MatMul",
+            inputs=[model_input_name, model_input_name],
+            outputs=[model_output_name],
+        )
+
+        # Create the graph (GraphProto)
+        graph_def = onnx.helper.make_graph(
+            nodes=[matmul_node],
+            name="ONNX_matmul",
+            inputs=[X],  # Graph input
+            outputs=[Y],  # Graph output
+        )
+
+        # Create the model (ModelProto)
+        model_def = onnx.helper.make_model(graph_def, producer_name="onnx-example")
+        model_def.opset_import[0].version = 13
+        onnx.checker.check_model(model_def)
+        onnx.save(model_def, self.tmpdir_name + "/model.onnx")
+
+        acetone_result = acetoneTestCase.run_acetone_for_test(self.tmpdir_name, self.tmpdir_name + "/model.onnx",target='AVX512VNNI')
+
+        self.assertListAlmostEqual(acetone_result[0], acetone_result[1])
+'''
+
+if __name__ == "__main__":
+    acetoneTestCase.main()

--- a/tests/tests_inference/tests_layer/test_c_python/test_QMatMul.py
+++ b/tests/tests_inference/tests_layer/test_c_python/test_QMatMul.py
@@ -80,7 +80,7 @@ class TestMatMul(acetoneTestCase.AcetoneTestCase):
         acetone_result = acetoneTestCase.run_acetone_for_test(self.tmpdir_name, self.tmpdir_name + "/model.onnx",target='AVX512VNNI')
 
         self.assertListAlmostEqual(list(acetone_result[0]), list(acetone_result[1]))
-'''
+
     def test_MatMul1(self):
         # IO tensors (ValueInfoProto).
         model_input_name = "X"
@@ -163,7 +163,7 @@ class TestMatMul(acetoneTestCase.AcetoneTestCase):
         acetone_result = acetoneTestCase.run_acetone_for_test(self.tmpdir_name, self.tmpdir_name + "/model.onnx",target='AVX512VNNI')
 
         self.assertListAlmostEqual(acetone_result[0], acetone_result[1])
-'''
+
 
 if __name__ == "__main__":
     acetoneTestCase.main()

--- a/tests/tests_inference/tests_layer/test_c_python/test_QMatMul.py
+++ b/tests/tests_inference/tests_layer/test_c_python/test_QMatMul.py
@@ -31,11 +31,37 @@ from tests.tests_inference import acetoneTestCase
 
 tf.keras.backend.set_floatx("float32")
 
+targetconf = '''
+{
+    "name":"AVX",
+    "cflags":"-mavx512vnni",
+    "quantization":
+    {
+        "dtype":"short",
+        "temp_dtype":"int",
+        "pydtype":"int16",
+        "layers":
+        {
+            "Input_layer_0":{
+                "out":"Q0.15"
+            },
+            "MatMul_1":{
+                "in":"Q0.15",
+                "params":"Q0.15",
+                "out":"Q2.13"
+            }
+        }
+    }  
+}
+'''
 
-class TestMatMul(acetoneTestCase.AcetoneTestCase):
-    """Test for Dense Layer"""
+def writeconf(conf):
+    with open('AVX512VNNI.json','w') as f:
+        f.write(conf)
 
-    def test_MatMul0(self):
+class TestQMatMul(acetoneTestCase.AcetoneTestCase):
+    def test_QMatMul0(self):
+        writeconf(targetconf)
         # IO tensors (ValueInfoProto).
         model_input_name = "X"
         X = onnx.helper.make_tensor_value_info(model_input_name,
@@ -81,7 +107,7 @@ class TestMatMul(acetoneTestCase.AcetoneTestCase):
 
         self.assertListAlmostEqual(list(acetone_result[0]), list(acetone_result[1]))
 
-    def test_MatMul1(self):
+    def test_QMatMul1(self):
         # IO tensors (ValueInfoProto).
         model_input_name = "X"
         X = onnx.helper.make_tensor_value_info(model_input_name,
@@ -127,7 +153,7 @@ class TestMatMul(acetoneTestCase.AcetoneTestCase):
 
         self.assertListAlmostEqual(acetone_result[0], acetone_result[1])
 
-    def test_MatMul2(self):
+    def test_QMatMul2(self):
         # IO tensors (ValueInfoProto).
         model_input_name = "X"
         X = onnx.helper.make_tensor_value_info(model_input_name,


### PR DESCRIPTION
[Ticket](https://github.com/onera/acetone/issues/26)

Existing MatMul template was adapted to manage Q feature.
use of target file configuration required <target.json> example in test_QMatMul.
The file shall be located in the CWD.
Target and Q feature are coupled (no need to quantize on native env).

Non regression tests **OK** : c_python
Test QMatMul **OK**.

Both python and c inference computation are pure integer without scaling.
The test data set is scaled to integer using max integer ranges, using _rint_ function.
The computation might overflow / wrap arround, but is the same for c and python.

Next step will focus on (re)-scaling feature, and more operators (dense, add, dot...)

